### PR TITLE
Fix retrieving DBPassword when it contains a "="

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -248,7 +248,7 @@ if [[ "${READ_ZBX_CONFIG}" == "yes" && -f "${ZBX_CONFIG}" && -r "${ZBX_CONFIG}" 
     DBNAME="$(/usr/bin/awk -F'=' '/^DBName/{ print $2 }' "${ZBX_CONFIG}")"
     DBSCHEMA="$(/usr/bin/awk -F'=' '/^DBSchema/{ print $2 }' "${ZBX_CONFIG}")"
     DBUSER="$(/usr/bin/awk -F'=' '/^DBUser/{ print $2 }' "${ZBX_CONFIG}")"
-    DBPASS="$(/usr/bin/awk -F'=' '/^DBPassword/{ print $2 }' "${ZBX_CONFIG}")"
+    DBPASS="$(/usr/bin/grep '^DBPassword=' "${ZBX_CONFIG}" | cut -d= -f2-)"
 
     # set non-existing variables to their Zabbix defaults (if they are non-empty string)
     [ -z ${DBHOST+x} ] && DBHOST="localhost"

--- a/zabbix-dump
+++ b/zabbix-dump
@@ -248,7 +248,7 @@ if [[ "${READ_ZBX_CONFIG}" == "yes" && -f "${ZBX_CONFIG}" && -r "${ZBX_CONFIG}" 
     DBNAME="$(/usr/bin/awk -F'=' '/^DBName/{ print $2 }' "${ZBX_CONFIG}")"
     DBSCHEMA="$(/usr/bin/awk -F'=' '/^DBSchema/{ print $2 }' "${ZBX_CONFIG}")"
     DBUSER="$(/usr/bin/awk -F'=' '/^DBUser/{ print $2 }' "${ZBX_CONFIG}")"
-    DBPASS="$(/usr/bin/grep '^DBPassword=' "${ZBX_CONFIG}" | cut -d= -f2-)"
+    DBPASS="$(/usr/bin/grep '^DBPassword=' "${ZBX_CONFIG}" | /usr/bin/cut -d= -f2-)"
 
     # set non-existing variables to their Zabbix defaults (if they are non-empty string)
     [ -z ${DBHOST+x} ] && DBHOST="localhost"


### PR DESCRIPTION
If your DB password contains an equal sign "=", the current `awk` code failed to retrieve the full password. AFAIK, using grep and cut is simpler than awk for this task.