### PR TITLE
netstat command is deprecated, switch to ss command instead

### DIFF
--- a/zabbix-dump
+++ b/zabbix-dump
@@ -259,7 +259,7 @@ if [[ "${READ_ZBX_CONFIG}" == "yes" && -f "${ZBX_CONFIG}" && -r "${ZBX_CONFIG}" 
     if [[ ( "$DBTYPE" == "mysql" && "$DBHOST" == "localhost" ) || ( "$DBTYPE" == "psql" && "$DBHOST" == "" ) ]]; then
         [ "$DBTYPE" == "mysql" ] && searchstr="mysqld.sock"
         [ "$DBTYPE" == "psql" ] && searchstr="postgres"
-        sock=$(netstat -lxn | grep -m1 "$searchstr" | sed -r 's/^.*\s+([^ ]+)$/\1/')
+        sock=$(ss -lax | grep -m1 "$searchstr" | column -t -o "#" | cut -d "#" -f 5)
         if [[ -n "$sock" && -S $sock ]]; then DBSOCKET="$sock"; DBHOST=""; fi
     else
         DBSOCKET="$(/usr/bin/awk -F'=' '/^DBSocket/{ print $2 }' "${ZBX_CONFIG}")"


### PR DESCRIPTION
The netstat command is deprecated and it is possible that it is not even installed anymore. The ss command is the replacement for this.

Use column command to split the columns instead of using a sed regex